### PR TITLE
Add countdown timer to level

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1,6 +1,8 @@
 $(function() {
     console.log("%c  ~~~  Bob v0.5 - Developed by d4rkd0s & d3mn5pwn ~~~  ", "color: #FFFFFF; font-size: 12px; background: #3F1338;");
     var game = new Phaser.Game(1156, 650, Phaser.CANVAS, '', { preload: preload, create: create, update: update, render: render });
+    var countdown;
+    var timerEvent;
     function preload() {
         //setting up starting vars
         max_apple_count = 100;
@@ -141,6 +143,9 @@ $(function() {
 
         //prime that apple
         apple.kill();
+        countdown = 60;
+        $('#timer').text('Time: ' + countdown);
+        timerEvent = game.time.events.loop(Phaser.Timer.SECOND, updateCountdown, this);
     }//create
 
     function onEnterFullScreen() {
@@ -153,6 +158,15 @@ $(function() {
 
         //do anything you want
 
+    }
+
+    function updateCountdown() {
+        countdown--;
+        $('#timer').text('Time: ' + countdown);
+        if (countdown <= 0) {
+            game.time.events.remove(timerEvent);
+            levelEnd(score, horseHealth);
+        }
     }
 
     function gofull() {

--- a/game.html
+++ b/game.html
@@ -10,7 +10,8 @@
     <div class="container text-center">
         <img src="assets/images/logo.png" id="logo"><br>
         <span id="score">Score: 0</span><br>
-        <span id="horseHealth">10 apples until your horse dies!</span>
+        <span id="horseHealth">10 apples until your horse dies!</span><br>
+        <span id="timer">Time: 60</span>
     </div>
     <embed  src="assets/player/player.swf" id="radioplayer" name="radioplayer"quality="medium" allowscriptaccess="always" width="1" height="1" type="application/x-shockwave-flash" flashvars="file=assets/music/game.mp3&volume=50&start=0&duration=0&autostart=true&controlbar=none&dock=false&icons=false"></embed>
     <script src="assets/js/jquery-3.1.1.min.js"></script>


### PR DESCRIPTION
## Summary
- show remaining time with new DOM span in `game.html`
- decrement countdown every second and stop game when it reaches zero

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc9beb2f48332b4a1f82c527dd09f