### PR TITLE
Use Phaser loop timer for apples

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -3,6 +3,8 @@ $(function() {
     var game = new Phaser.Game(1156, 650, Phaser.CANVAS, '', { preload: preload, create: create, update: update, render: render });
     var countdown;
     var timerEvent;
+    var appleLoop;
+    var appleDelay = 3000;
     function preload() {
         //setting up starting vars
         max_apple_count = 100;
@@ -68,8 +70,8 @@ $(function() {
 
         //walk step speed in ms
         setInterval(clock, 100);
-        //spawn apple in ms
-        setInterval(appleTick, 3000);
+        //spawn apple in ms using Phaser timer
+        appleLoop = game.time.events.loop(appleDelay, appleTick, this);
         //notify user (console)
         console.log("%c   walking: enabled   ", "color: #FFFFFF; font-size: 10px; background: #5CA6FF;");
     }//preload
@@ -192,6 +194,14 @@ $(function() {
     }
 
     function update() {
+
+        // adjust apple spawn timer based on score
+        var newDelay = Math.max(3000 - score * 50, 1000);
+        if (newDelay !== appleDelay) {
+            appleDelay = newDelay;
+            game.time.events.remove(appleLoop);
+            appleLoop = game.time.events.loop(appleDelay, appleTick, this);
+        }
 
         var curTime = game.time.totalElapsedSeconds();
         apple.bringToTop();


### PR DESCRIPTION
## Summary
- replace `setInterval` with Phaser loop timer for apple spawning
- dynamically lower spawn delay as score increases

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abcfa98e4c833282fe18820531b25e