### PR TITLE
Fix timer to count up from zero

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -1,7 +1,7 @@
 $(function() {
     console.log("%c  ~~~  Bob v0.5 - Developed by d4rkd0s & d3mn5pwn ~~~  ", "color: #FFFFFF; font-size: 12px; background: #3F1338;");
     var game = new Phaser.Game(1156, 650, Phaser.CANVAS, '', { preload: preload, create: create, update: update, render: render });
-    var countdown;
+    var elapsedTime;
     var timerEvent;
     var bushes;
     var bushsound;
@@ -176,9 +176,9 @@ $(function() {
 
         //prime that apple
         apple.kill();
-        countdown = 60;
-        $('#timer').text('Time: ' + countdown);
-        timerEvent = game.time.events.loop(Phaser.Timer.SECOND, updateCountdown, this);
+        elapsedTime = 0;
+        $('#timer').text('Time: ' + elapsedTime);
+        timerEvent = game.time.events.loop(Phaser.Timer.SECOND, updateTimer, this);
     }//create
 
     function onEnterFullScreen() {
@@ -193,13 +193,9 @@ $(function() {
 
     }
 
-    function updateCountdown() {
-        countdown--;
-        $('#timer').text('Time: ' + countdown);
-        if (countdown <= 0) {
-            game.time.events.remove(timerEvent);
-            levelEnd(score, horseHealth);
-        }
+    function updateTimer() {
+        elapsedTime++;
+        $('#timer').text('Time: ' + elapsedTime);
     }
 
     function gofull() {

--- a/game.html
+++ b/game.html
@@ -11,7 +11,7 @@
         <img src="assets/images/logo.png" id="logo"><br>
         <span id="score">Score: 0</span><br>
         <span id="horseHealth">10 apples until your horse dies!</span><br>
-        <span id="timer">Time: 60</span>
+        <span id="timer">Time: 0</span>
     </div>
     <embed  src="assets/player/player.swf" id="radioplayer" name="radioplayer"quality="medium" allowscriptaccess="always" width="1" height="1" type="application/x-shockwave-flash" flashvars="file=assets/music/game.mp3&volume=50&start=0&duration=0&autostart=true&controlbar=none&dock=false&icons=false"></embed>
     <script src="assets/js/jquery-3.1.1.min.js"></script>


### PR DESCRIPTION
## Summary
- Initialize elapsed time at 0 and increment each second
- Update timer display to show starting value of 0

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abd191c8308332a4ed142cfcf1c7ff