### PR TITLE
Fix runtime crash by using group getClosestTo

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -330,7 +330,7 @@ $(function() {
         //move mr.horse
         if (apples.countLiving() > 0)
         {
-            var targetApple = game.physics.arcade.closest(horse, apples);
+            var targetApple = apples.getClosestTo(horse);
             horse.velocity = game.physics.arcade.accelerateToObject(horse, targetApple, 50+(score*5), 50+(score*5), 50+(score*5));
             horse.loadTexture(horseFrames[hoof]);
             if (horse.body.velocity.x < 0) {


### PR DESCRIPTION
## Summary
- Replace deprecated `game.physics.arcade.closest` with `apples.getClosestTo` to target nearest apple

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1fbd92288332a88a16b73ad80e24