### PR TITLE
Implement Phaser 2 nearest object helper

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -330,7 +330,7 @@ $(function() {
         //move mr.horse
         if (apples.countLiving() > 0)
         {
-            var targetApple = apples.getClosestTo(horse);
+            var targetApple = getClosest(game, horse, apples);
             horse.velocity = game.physics.arcade.accelerateToObject(horse, targetApple, 50+(score*5), 50+(score*5), 50+(score*5));
             horse.loadTexture(horseFrames[hoof]);
             if (horse.body.velocity.x < 0) {

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -2,6 +2,21 @@ function computeAppleDelay(score) {
   return Math.max(3000 - score * 50, 1000);
 }
 
+function getClosest(game, target, group) {
+  var closest = null;
+  var shortest = Number.MAX_VALUE;
+  if (group && group.forEachAlive) {
+    group.forEachAlive(function(child) {
+      var dist = game.physics.arcade.distanceBetween(target, child);
+      if (dist < shortest) {
+        shortest = dist;
+        closest = child;
+      }
+    });
+  }
+  return closest;
+}
+
 if (typeof module !== 'undefined') {
-  module.exports = { computeAppleDelay };
+  module.exports = { computeAppleDelay, getClosest };
 }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { computeAppleDelay } = require('../assets/js/helpers.js');
+const { computeAppleDelay, getClosest } = require('../assets/js/helpers.js');
 
 describe('computeAppleDelay', function() {
   it('returns 3000 when score is 0', function() {
@@ -12,5 +12,20 @@ describe('computeAppleDelay', function() {
 
   it('never goes below 1000', function() {
     assert.strictEqual(computeAppleDelay(100), 1000);
+  });
+});
+
+describe('getClosest', function() {
+  it('returns the nearest object', function() {
+    const game = { physics: { arcade: { distanceBetween: (a, b) => Math.hypot(a.x - b.x, a.y - b.y) } } };
+    const target = { x: 0, y: 0 };
+    const group = [
+      { x: 5, y: 0 },
+      { x: 2, y: 2 },
+      { x: 3, y: 4 }
+    ];
+    group.forEachAlive = function(cb, ctx) { this.forEach(function(child) { cb.call(ctx, child); }); };
+    const closest = getClosest(game, target, group);
+    assert.strictEqual(closest, group[1]);
   });
 });


### PR DESCRIPTION
## Summary
- Add `getClosest` helper using Arcade Physics distance to find nearest sprite
- Use `getClosest` in horse AI to replace deprecated API
- Add unit test for `getClosest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad217afbec83329d343eb5d8e85eb1